### PR TITLE
Add CLOAKPROTECT access control front controller and dashboard

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine On
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^(.*)$ index.php [QSA,L]

--- a/api/heartbeat.php
+++ b/api/heartbeat.php
@@ -1,0 +1,7 @@
+<?php
+require __DIR__ . '/../includes/bootstrap.php';
+$ip = get_ip();
+$page = $_GET['page'] ?? '';
+update_visit($ip, $page, !empty($_SESSION['human']));
+echo 'ok';
+?>

--- a/api/mark_human.php
+++ b/api/mark_human.php
@@ -1,0 +1,8 @@
+<?php
+require __DIR__ . '/../includes/bootstrap.php';
+$_SESSION['human'] = true;
+$ip = get_ip();
+$page = $_GET['page'] ?? '';
+update_visit($ip, $page, true);
+echo 'ok';
+?>

--- a/assets/heartbeat.js
+++ b/assets/heartbeat.js
@@ -1,0 +1,3 @@
+setInterval(function() {
+  fetch('/api/heartbeat.php?page=' + encodeURIComponent(location.pathname + location.search), {credentials: 'same-origin'});
+}, 30000);

--- a/assets/human.js
+++ b/assets/human.js
@@ -1,0 +1,2 @@
+fetch('/api/mark_human.php', {credentials: 'same-origin'})
+  .then(() => window.location.reload());

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,7 @@
+body { font-family: Arial, sans-serif; margin: 20px; background: #f9f9f9; }
+table { border-collapse: collapse; }
+th, td { padding: 4px 8px; border: 1px solid #ccc; }
+label { display: block; margin: 8px 0; }
+.indent { margin-left: 20px; }
+input[type=text], input[type=password], input[type=time] { padding: 4px; }
+button { padding: 6px 12px; }

--- a/dashboard/allow.php
+++ b/dashboard/allow.php
@@ -1,0 +1,13 @@
+<?php
+require __DIR__ . '/../includes/bootstrap.php';
+if (empty($_SESSION['admin'])) { header('Location: login.php'); exit; }
+$ip = $_POST['ip'] ?? '';
+if ($ip) {
+    $db = get_db();
+    $stmt = $db->prepare('REPLACE INTO allowed_ips (ip) VALUES (?)');
+    $stmt->execute([$ip]);
+    log_event($ip, '', 'allow');
+}
+header('Location: index.php');
+exit;
+?>

--- a/dashboard/block.php
+++ b/dashboard/block.php
@@ -1,0 +1,13 @@
+<?php
+require __DIR__ . '/../includes/bootstrap.php';
+if (empty($_SESSION['admin'])) { header('Location: login.php'); exit; }
+$ip = $_POST['ip'] ?? '';
+if ($ip) {
+    $db = get_db();
+    $stmt = $db->prepare('REPLACE INTO blocked_ips (ip) VALUES (?)');
+    $stmt->execute([$ip]);
+    log_event($ip, '', 'block');
+}
+header('Location: index.php');
+exit;
+?>

--- a/dashboard/index.php
+++ b/dashboard/index.php
@@ -1,0 +1,51 @@
+<?php
+require __DIR__ . '/../includes/bootstrap.php';
+if (empty($_SESSION['admin'])) {
+    header('Location: login.php');
+    exit;
+}
+
+$db = get_db();
+$visStmt = $db->prepare('SELECT ip, last_page, last_activity FROM visits WHERE last_activity > ?');
+$visStmt->execute([time() - 300]);
+$visitors = $visStmt->fetchAll(PDO::FETCH_ASSOC);
+$blocked = $db->query('SELECT ip FROM blocked_ips')->fetchAll(PDO::FETCH_ASSOC);
+$allowed = $db->query('SELECT ip FROM allowed_ips')->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!doctype html>
+<html>
+<head><title>Dashboard</title><link rel="stylesheet" href="/assets/style.css"></head>
+<body>
+<h1>Dashboard</h1>
+<p><a href="logout.php">Logout</a> | <a href="settings.php">Configurações</a></p>
+<h2>Visitantes Online</h2>
+<table>
+<tr><th>IP</th><th>Última Página</th><th>Última Atividade</th></tr>
+<?php foreach ($visitors as $v): ?>
+<tr><td><?=htmlspecialchars($v['ip'])?></td><td><?=htmlspecialchars($v['last_page'])?></td><td><?=date('H:i:s', $v['last_activity'])?></td></tr>
+<?php endforeach; ?>
+</table>
+
+<h2>Bloquear IP</h2>
+<form method="post" action="block.php">
+  <input name="ip" placeholder="IP" required>
+  <button type="submit">Bloquear</button>
+</form>
+<ul>
+<?php foreach ($blocked as $b): ?>
+<li><?=htmlspecialchars($b['ip'])?> <form style="display:inline" method="post" action="unblock.php"><input type="hidden" name="ip" value="<?=htmlspecialchars($b['ip'])?>"><button>Desbloquear</button></form></li>
+<?php endforeach; ?>
+</ul>
+
+<h2>Autorizar IP</h2>
+<form method="post" action="allow.php">
+  <input name="ip" placeholder="IP" required>
+  <button type="submit">Autorizar</button>
+</form>
+<ul>
+<?php foreach ($allowed as $a): ?>
+<li><?=htmlspecialchars($a['ip'])?> <form style="display:inline" method="post" action="unallow.php"><input type="hidden" name="ip" value="<?=htmlspecialchars($a['ip'])?>"><button>Remover</button></form></li>
+<?php endforeach; ?>
+</ul>
+</body>
+</html>

--- a/dashboard/login.php
+++ b/dashboard/login.php
@@ -1,0 +1,33 @@
+<?php
+require __DIR__ . '/../includes/bootstrap.php';
+
+if (isset($_POST['user'], $_POST['pass'])) {
+    $user = $_POST['user'];
+    $pass = $_POST['pass'];
+    $hash = get_setting('admin_pass');
+    if (!$hash) {
+        $hash = password_hash('admin', PASSWORD_DEFAULT);
+        set_setting('admin_pass', $hash);
+    }
+    if ($user === 'admin' && password_verify($pass, $hash)) {
+        $_SESSION['admin'] = true;
+        header('Location: index.php');
+        exit;
+    } else {
+        $error = 'Login inválido';
+    }
+}
+?>
+<!doctype html>
+<html>
+<head><title>Login</title><link rel="stylesheet" href="/assets/style.css"></head>
+<body>
+<h1>Login</h1>
+<?php if (!empty($error)) echo '<p style="color:red">'.$error.'</p>'; ?>
+<form method="post">
+  <label>Usuário: <input type="text" name="user"></label><br>
+  <label>Senha: <input type="password" name="pass"></label><br>
+  <button type="submit">Entrar</button>
+</form>
+</body>
+</html>

--- a/dashboard/logout.php
+++ b/dashboard/logout.php
@@ -1,0 +1,6 @@
+<?php
+require __DIR__ . '/../includes/bootstrap.php';
+unset($_SESSION['admin']);
+header('Location: login.php');
+exit;
+?>

--- a/dashboard/settings.php
+++ b/dashboard/settings.php
@@ -1,0 +1,65 @@
+<?php
+require __DIR__ . '/../includes/bootstrap.php';
+if (empty($_SESSION['admin'])) { header('Location: login.php'); exit; }
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['home'])) {
+        set_setting('home', $_POST['home']);
+    }
+    if (isset($_POST['blocked_redirect'])) {
+        set_setting('blocked_redirect', $_POST['blocked_redirect']);
+    }
+    set_setting('redirect_schedule_enabled', isset($_POST['redirect_schedule_enabled']) ? '1' : '0');
+    set_setting('redirect_schedule_url', $_POST['redirect_schedule_url'] ?? '');
+    set_setting('redirect_schedule_start', $_POST['redirect_schedule_start'] ?? '');
+    set_setting('redirect_schedule_end', $_POST['redirect_schedule_end'] ?? '');
+    set_setting('redirect_refer_enabled', isset($_POST['redirect_refer_enabled']) ? '1' : '0');
+    set_setting('redirect_refer_pattern', $_POST['redirect_refer_pattern'] ?? '');
+    set_setting('redirect_refer_url', $_POST['redirect_refer_url'] ?? '');
+    if (!empty($_POST['new_pass'])) {
+        set_setting('admin_pass', password_hash($_POST['new_pass'], PASSWORD_DEFAULT));
+    }
+    $msg = 'Salvo!';
+}
+$home = get_setting('home', 'sites/home/index.php');
+$blocked_redirect = get_setting('blocked_redirect', 'sites/blocked/index.php');
+$redirect_schedule_enabled = get_setting('redirect_schedule_enabled', '0');
+$redirect_schedule_url = get_setting('redirect_schedule_url', '');
+$redirect_schedule_start = get_setting('redirect_schedule_start', '');
+$redirect_schedule_end = get_setting('redirect_schedule_end', '');
+$redirect_refer_enabled = get_setting('redirect_refer_enabled', '0');
+$redirect_refer_pattern = get_setting('redirect_refer_pattern', '');
+$redirect_refer_url = get_setting('redirect_refer_url', '');
+?>
+<!doctype html>
+<html>
+<head><title>Configurações</title><link rel="stylesheet" href="/assets/style.css"></head>
+<body>
+<h1>Configurações</h1>
+<p><a href="index.php">Voltar</a></p>
+<?php if (!empty($msg)) echo '<p style="color:green">'.$msg.'</p>'; ?>
+<form method="post">
+  <label>Home:
+    <input type="text" name="home" value="<?=htmlspecialchars($home)?>">
+  </label>
+  <label>Destino bloqueado:
+    <input type="text" name="blocked_redirect" value="<?=htmlspecialchars($blocked_redirect)?>">
+  </label>
+  <label><input type="checkbox" name="redirect_schedule_enabled" value="1" <?= $redirect_schedule_enabled?'checked':'' ?>> Ativar redirecionamento por horário</label>
+  <div class="indent">
+    <label>Início: <input type="time" name="redirect_schedule_start" value="<?=htmlspecialchars($redirect_schedule_start)?>"></label>
+    <label>Fim: <input type="time" name="redirect_schedule_end" value="<?=htmlspecialchars($redirect_schedule_end)?>"></label>
+    <label>URL destino: <input type="text" name="redirect_schedule_url" value="<?=htmlspecialchars($redirect_schedule_url)?>"></label>
+  </div>
+  <label><input type="checkbox" name="redirect_refer_enabled" value="1" <?= $redirect_refer_enabled?'checked':'' ?>> Ativar redirecionamento por referer</label>
+  <div class="indent">
+    <label>Referer contém: <input type="text" name="redirect_refer_pattern" value="<?=htmlspecialchars($redirect_refer_pattern)?>"></label>
+    <label>URL destino: <input type="text" name="redirect_refer_url" value="<?=htmlspecialchars($redirect_refer_url)?>"></label>
+  </div>
+  <label>Nova senha:
+    <input type="password" name="new_pass">
+  </label>
+  <button type="submit">Salvar</button>
+</form>
+</body>
+</html>

--- a/dashboard/unallow.php
+++ b/dashboard/unallow.php
@@ -1,0 +1,13 @@
+<?php
+require __DIR__ . '/../includes/bootstrap.php';
+if (empty($_SESSION['admin'])) { header('Location: login.php'); exit; }
+$ip = $_POST['ip'] ?? '';
+if ($ip) {
+    $db = get_db();
+    $stmt = $db->prepare('DELETE FROM allowed_ips WHERE ip = ?');
+    $stmt->execute([$ip]);
+    log_event($ip, '', 'unallow');
+}
+header('Location: index.php');
+exit;
+?>

--- a/dashboard/unblock.php
+++ b/dashboard/unblock.php
@@ -1,0 +1,13 @@
+<?php
+require __DIR__ . '/../includes/bootstrap.php';
+if (empty($_SESSION['admin'])) { header('Location: login.php'); exit; }
+$ip = $_POST['ip'] ?? '';
+if ($ip) {
+    $db = get_db();
+    $stmt = $db->prepare('DELETE FROM blocked_ips WHERE ip = ?');
+    $stmt->execute([$ip]);
+    log_event($ip, '', 'unblock');
+}
+header('Location: index.php');
+exit;
+?>

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+session_start();
+require_once __DIR__ . '/functions.php';
+get_db();
+?>

--- a/includes/db.php
+++ b/includes/db.php
@@ -1,0 +1,39 @@
+<?php
+function get_db()
+{
+    static $db = null;
+    if ($db) {
+        return $db;
+    }
+    $path = __DIR__ . '/../storage/data.sqlite';
+    if (!file_exists(dirname($path))) {
+        mkdir(dirname($path), 0775, true);
+    }
+    $db = new PDO('sqlite:' . $path);
+    $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    $db->exec('CREATE TABLE IF NOT EXISTS blocked_ips (ip TEXT PRIMARY KEY)');
+    $db->exec('CREATE TABLE IF NOT EXISTS allowed_ips (ip TEXT PRIMARY KEY)');
+    $db->exec('CREATE TABLE IF NOT EXISTS visits (
+        session_id TEXT PRIMARY KEY,
+        ip TEXT,
+        user_agent TEXT,
+        last_page TEXT,
+        last_activity INTEGER,
+        human INTEGER DEFAULT 0
+    )');
+    $db->exec('CREATE TABLE IF NOT EXISTS events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        ip TEXT,
+        page TEXT,
+        ts INTEGER,
+        action TEXT
+    )');
+    $db->exec('CREATE TABLE IF NOT EXISTS settings (
+        key TEXT PRIMARY KEY,
+        value TEXT
+    )');
+
+    return $db;
+}
+?>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,0 +1,69 @@
+<?php
+require_once __DIR__ . '/db.php';
+
+function get_ip()
+{
+    if (!empty($_SERVER['HTTP_CF_CONNECTING_IP'])) {
+        $ip = $_SERVER['HTTP_CF_CONNECTING_IP'];
+    } elseif (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+        $parts = explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']);
+        $ip = trim($parts[0]);
+    } else {
+        $ip = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
+    }
+    return filter_var($ip, FILTER_VALIDATE_IP) ? $ip : '0.0.0.0';
+}
+
+function get_setting($key, $default = null)
+{
+    $db = get_db();
+    $stmt = $db->prepare('SELECT value FROM settings WHERE key = ?');
+    $stmt->execute([$key]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    return $row ? $row['value'] : $default;
+}
+
+function set_setting($key, $value)
+{
+    $db = get_db();
+    $stmt = $db->prepare('REPLACE INTO settings (key, value) VALUES (?, ?)');
+    $stmt->execute([$key, $value]);
+}
+
+function is_blocked($ip)
+{
+    $db = get_db();
+    $stmt = $db->prepare('SELECT 1 FROM blocked_ips WHERE ip = ?');
+    $stmt->execute([$ip]);
+    return (bool)$stmt->fetchColumn();
+}
+
+function is_allowed($ip)
+{
+    $db = get_db();
+    $stmt = $db->prepare('SELECT 1 FROM allowed_ips WHERE ip = ?');
+    $stmt->execute([$ip]);
+    return (bool)$stmt->fetchColumn();
+}
+
+function log_event($ip, $page, $action)
+{
+    $db = get_db();
+    $stmt = $db->prepare('INSERT INTO events (ip, page, ts, action) VALUES (?, ?, ?, ?)');
+    $stmt->execute([$ip, $page, time(), $action]);
+}
+
+function update_visit($ip, $page, $human)
+{
+    $db = get_db();
+    $stmt = $db->prepare('REPLACE INTO visits (session_id, ip, user_agent, last_page, last_activity, human) VALUES (?, ?, ?, ?, ?, ?)');
+    $stmt->execute([
+        session_id(),
+        $ip,
+        $_SERVER['HTTP_USER_AGENT'] ?? '',
+        $page,
+        time(),
+        $human ? 1 : 0
+    ]);
+}
+?>

--- a/includes/guard.php
+++ b/includes/guard.php
@@ -1,0 +1,51 @@
+<?php
+require_once __DIR__ . '/functions.php';
+
+function run_guard($requested)
+{
+    $ip = get_ip();
+
+    if (is_blocked($ip)) {
+        $dest = get_setting('blocked_redirect', 'sites/blocked/index.php');
+        if (filter_var($dest, FILTER_VALIDATE_URL)) {
+            header('Location: ' . $dest);
+        } else {
+            include __DIR__ . '/../' . ltrim($dest, '/');
+        }
+        log_event($ip, $requested, 'blocked');
+        exit;
+    }
+
+    $now = date('H:i');
+    if (get_setting('redirect_schedule_enabled', '0') && ($url = get_setting('redirect_schedule_url'))) {
+        $start = get_setting('redirect_schedule_start', '00:00');
+        $end   = get_setting('redirect_schedule_end', '00:00');
+        $inWindow = ($start <= $end) ? ($now >= $start && $now <= $end)
+                                     : ($now >= $start || $now <= $end);
+        if ($inWindow) {
+            header('Location: ' . $url);
+            exit;
+        }
+    }
+
+    if (get_setting('redirect_refer_enabled', '0') && ($pattern = get_setting('redirect_refer_pattern'))) {
+        $referer = $_SERVER['HTTP_REFERER'] ?? '';
+        if ($referer && stripos($referer, $pattern) !== false) {
+            $url = get_setting('redirect_refer_url');
+            if ($url) {
+                header('Location: ' . $url);
+                exit;
+            }
+        }
+    }
+
+    if (!is_allowed($ip) && empty($_SESSION['human'])) {
+        header('Content-Type: text/html; charset=utf-8');
+        echo "<!doctype html><html><head><title>Verificação</title></head><body><p>Verificando...</p><script src='/assets/human.js'></script></body></html>";
+        log_event($ip, $requested, 'verify');
+        exit;
+    }
+
+    update_visit($ip, $requested, !empty($_SESSION['human']));
+}
+?>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,29 @@
+<?php
+require __DIR__ . '/includes/bootstrap.php';
+require __DIR__ . '/includes/guard.php';
+
+$requested = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+$requested = ltrim($requested, '/');
+
+$home = get_setting('home', 'sites/home/index.php');
+$homeDir = realpath(__DIR__ . '/' . dirname($home));
+$target = realpath($homeDir . '/' . $requested);
+
+if ($target === false || strpos($target, $homeDir) !== 0 || !is_file($target)) {
+    $target = __DIR__ . '/' . $home;
+    $requested = basename($home);
+}
+
+run_guard($requested);
+http_response_code(200);
+ob_start();
+include $target;
+$content = ob_get_clean();
+if (stripos($content, '</body>') !== false) {
+    $content = str_ireplace('</body>', "<script src='/assets/heartbeat.js'></script></body>", $content);
+} else {
+    $content .= "<script src='/assets/heartbeat.js'></script>";
+}
+
+echo $content;
+?>

--- a/sites/blocked/index.php
+++ b/sites/blocked/index.php
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+<head><title>Acesso Bloqueado</title></head>
+<body>
+<h1>Seu acesso foi bloqueado.</h1>
+</body>
+</html>

--- a/sites/home/index.php
+++ b/sites/home/index.php
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+<head><title>Home</title></head>
+<body>
+<h1>Bem-vindo à Home</h1>
+<p>Este é o conteúdo da sua home.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Improve IP detection to honor Cloudflare headers
- Add optional redirects by schedule and referer with dashboard controls and styling
- Force HTTP 200 fallback to avoid 404 when file not found

## Testing
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68acca0ca290832296298534f60c33c5